### PR TITLE
Fixes dependencies order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 credentials.json
 __pycache__/
 /.vscode
+/.venv
 
 *.DS_Store
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-requests==2.21.0
-tqdm==4.31.1
-numpy==1.13.3
-matplotlib==2.0.2
-pandas==0.24.1
-requests_oauthlib==1.2.0
+matplotlib==3.5.2
+numpy==1.23.1
+pandas==1.4.3
+requests==2.28.1
+requests-oauthlib==1.3.1
+tqdm==4.64.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.21.0
 tqdm==4.31.1
+numpy==1.13.3
 matplotlib==2.0.2
 pandas==0.24.1
 requests_oauthlib==1.2.0
-numpy==1.13.3


### PR DESCRIPTION
Updated the requirements' versions in `requirements.txt` to fix the build (in Python 3.10).  

I tested running a query with a target and download set and it worked.